### PR TITLE
Fix deadlock in trace thread shutdown

### DIFF
--- a/shared/trace.c
+++ b/shared/trace.c
@@ -429,7 +429,7 @@ void trace_destroy(void)
 
 	if (trinf) {
 		/* wait for writer to finish with queued bufs */
-		wait_event(&trinf->waitq, !cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
+		wait_event(&trinf->waitq, cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
 
 		/* then shut it down */
 		thread_stop_indicate(&trinf->write_thr);


### PR DESCRIPTION
The wait_event() in trace_destroy() was supposed to wait for the trace write buffer queue to be empty, but instead it was waiting for it to be non-empty. Reverse the wait condition.