### PR TITLE
Compile and thread shutdown fixes.

### DIFF
--- a/shared/thread.c
+++ b/shared/thread.c
@@ -9,6 +9,7 @@
 #include <signal.h>
 #include <pthread.h>
 #include <urcu.h>
+#include <assert.h>
 
 #include "shared/lk/bitops.h"
 

--- a/shared/trace.c
+++ b/shared/trace.c
@@ -429,7 +429,7 @@ void trace_destroy(void)
 
 	if (trinf) {
 		/* wait for writer to finish with queued bufs */
-		wait_event(&trinf->waitq, !cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
+		wait_event(&trinf->waitq, cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
 
 		/* then shut it down */
 		thread_stop_indicate(&trinf->write_thr);

--- a/shared/trace.c
+++ b/shared/trace.c
@@ -259,7 +259,7 @@ void trace_flush(void)
 	rcu_read_unlock();
 
 	/* wait for writer to finish with queued bufs */
-	wait_event(&trinf->waitq, !cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
+	wait_event(&trinf->waitq, cds_wfcq_empty(&trinf->write_head, &trinf->write_tail));
 }
 
 static void put_list_bufs(struct list_head *list)


### PR DESCRIPTION
Includes the assert.h include (with explanation) and the 2 thread shutdown hangs due to inverted wait condition.